### PR TITLE
Split cleaning into two stages.

### DIFF
--- a/yapinator.js
+++ b/yapinator.js
@@ -659,6 +659,12 @@
 			rmnth: function( s ) {
 				return s.replace( /\(\s*even\s*\)/gi, "(2n)").replace( /\(\s*odd\s*\)/gi, "(2n+1)");
 			},
+			preclean: function ( s ) {
+				return this.rmnth( this.rms( s ) );
+			},
+			postclean: function ( s ) {
+				return this.rmb( this.rmq( s ) );
+			},
 			// total clean
 			clean: function( s ) {
 				return this.rmnth( this.rmb( this.rmq( this.rms( s ) ) ) );
@@ -739,10 +745,11 @@
 			version: version,
 			// main selector function
 			select: function( selector, root, noCache, loop, nthrun ) {
+				var oldSelector = cleaner.preclean(selector);
 				// Return cache if exists
 				// Return no cached result if root specified
-				if ( cache[ selector ] && !noCache && !root ) {
-					return cache[ selector ];
+				if ( cache[ oldSelector ] && !noCache && !root ) {
+					return cache[ oldSelector ];
 				}
 				// re-define noCache
 				noCache = noCache || !!root;
@@ -756,7 +763,7 @@
 					return [];
 				}
 				// clean selector
-				selector = cleaner.clean(selector);
+				selector = cleaner.postclean(oldSelector);
 				var m, set;
 				// qucik selection - only ID, CLASS TAG, and ATTR for the very first occurence
 				if ( ( m = selectors.reg.sharpTest.exec( selector ) ) !== null ) {
@@ -816,7 +823,7 @@
 						cleaner.cleanElem( set );
 					}
 				}
-				return !noCache ? cache[ selector ] = set: set;
+				return !noCache ? cache[ oldSelector ] = set: set;
 			},
 			Loader: function (){
 				DOMChngEvent();


### PR DESCRIPTION
This puts the odd/even => 2n+1/2n and whitespace trim functions in a before
cache lookup evaluation, and defers the others to post-cache lookup. In effect,
it allows :nth-child(2n) and :nth-child(even) to equate to the same cache
item, while keeping extra string transformations from slowing down the
cache key computation.

Also fixes a (bug?) where query results aren't stored in the cache by their inputs,
making :nth-child(even) and family uncacheable.
